### PR TITLE
Allow observation of syscall error

### DIFF
--- a/gexec.go
+++ b/gexec.go
@@ -11,7 +11,7 @@ import (
 type GroupedCmd struct {
 	*exec.Cmd
 	pgid      int
-	jobObject *jobObject
+	JobObject *jobObject
 }
 
 func Grouped(cmd *exec.Cmd) *GroupedCmd {

--- a/gexec_windows.go
+++ b/gexec_windows.go
@@ -6,46 +6,15 @@ package gexec
 import (
 	"errors"
 	"os"
-
-	"golang.org/x/sys/windows"
-)
-
-// process-specific access rights.
-// https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights
-const (
-	PROCESS_SET_QUOTA = 0x0100
-	PROCESS_TERMINATE = 0x0001
 )
 
 func (c *GroupedCmd) start() error {
 	if err := c.Cmd.Start(); err != nil {
 		return err
 	}
-	c.jobObject = newJobObject()
-	assignProcessToJobObject(c.Cmd.Process, c.jobObject)
+	c.JobObject = newJobObject()
+	c.JobObject.assignProcess(c.Cmd.Process)
 	return nil
-}
-
-func assignProcessToJobObject(process *os.Process, job *jobObject) {
-	procHandle, err := windows.OpenProcess(PROCESS_SET_QUOTA|PROCESS_TERMINATE, false, uint32(process.Pid))
-	if err != nil {
-		job.err = os.NewSyscallError("OpenProcess", err)
-		return
-	}
-	defer windows.CloseHandle(procHandle)
-
-	jobHandle, err := windows.CreateJobObject(nil, nil)
-	if err != nil {
-		job.err = os.NewSyscallError("CreateJobObject", err)
-		return
-	}
-	job.handle = uintptr(jobHandle)
-
-	err = windows.AssignProcessToJobObject(jobHandle, procHandle)
-	if err != nil {
-		defer job.close()
-		job.err = os.NewSyscallError("AssignProcessToJobObject", err)
-	}
 }
 
 func (c *GroupedCmd) signalAll(sig os.Signal) error {
@@ -53,5 +22,5 @@ func (c *GroupedCmd) signalAll(sig os.Signal) error {
 		return errors.New("unsupported signal type")
 	}
 
-	return c.jobObject.terminate()
+	return c.JobObject.terminate()
 }

--- a/job_object.go
+++ b/job_object.go
@@ -6,6 +6,6 @@ import (
 
 type jobObject struct {
 	handle uintptr
-	err    error
+	Err    error
 	sigMu  sync.RWMutex
 }


### PR DESCRIPTION
Allows observation of syscall error that occur when creating a job object or assigning a process to a job object.